### PR TITLE
WebView based MXT Cache

### DIFF
--- a/JetpackSAM/app/src/main/AndroidManifest.xml
+++ b/JetpackSAM/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     package="com.example.jetpacksam">
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
@@ -12,7 +12,6 @@
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
 
-
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -20,17 +19,23 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <receiver android:name="HeadsetStateChangedReceiver" android:exported="true">
+        <activity android:name="com.memoryexpansiontools.mxt.CacheActivity"></activity>
+
+        <receiver
+            android:name=".HeadsetStateChangedReceiver"
+            android:exported="true">
             <intent-filter>
-                <action android:name="android.bluetooth.headset.profile.action.CONNECTION_STATE_CHANGED"/>
+                <action android:name="android.bluetooth.headset.profile.action.CONNECTION_STATE_CHANGED" />
             </intent-filter>
         </receiver>
+
         <service
             android:name=".TranscribeIntentService"
-            android:exported="false"></service>
+            android:exported="false" />
         <service
             android:name=".RecordAudioIntentService"
             android:exported="false" />
+
         <activity
             android:name=".SettingsActivity"
             android:label="@string/title_activity_settings"
@@ -57,8 +62,7 @@
         </activity>
         <activity
             android:name=".LoginActivity"
-            android:screenOrientation="portrait">
-        </activity>
+            android:screenOrientation="portrait"></activity>
     </application>
 
 </manifest>

--- a/JetpackSAM/app/src/main/java/com/memoryexpansiontools/mxt/CacheActivity.java
+++ b/JetpackSAM/app/src/main/java/com/memoryexpansiontools/mxt/CacheActivity.java
@@ -1,0 +1,22 @@
+package com.memoryexpansiontools.mxt;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import android.os.Bundle;
+import android.webkit.WebView;
+
+import com.example.jetpacksam.R;
+
+public class CacheActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_cache);
+
+        //Create and load a webview pointed at the memoryexpansiontools website
+        //This allows the user to access MXT Cache directly within the app.
+        WebView cacheWebView = (WebView) findViewById(R.id.cacheView);
+        cacheWebView.loadUrl("memoryexpansiontools.com");
+    }
+}

--- a/JetpackSAM/app/src/main/java/com/memoryexpansiontools/mxt/CacheActivity.java
+++ b/JetpackSAM/app/src/main/java/com/memoryexpansiontools/mxt/CacheActivity.java
@@ -3,6 +3,7 @@ package com.memoryexpansiontools.mxt;
 import androidx.appcompat.app.AppCompatActivity;
 
 import android.os.Bundle;
+import android.webkit.WebSettings;
 import android.webkit.WebView;
 
 import com.example.jetpacksam.R;
@@ -17,6 +18,15 @@ public class CacheActivity extends AppCompatActivity {
         //Create and load a webview pointed at the memoryexpansiontools website
         //This allows the user to access MXT Cache directly within the app.
         WebView cacheWebView = (WebView) findViewById(R.id.cacheView);
-        cacheWebView.loadUrl("memoryexpansiontools.com");
+        WebSettings webSettings = cacheWebView.getSettings();
+        webSettings.setJavaScriptEnabled(true);
+        webSettings.setDomStorageEnabled(true);
+        webSettings.setLoadWithOverviewMode(true);
+        webSettings.setUseWideViewPort(true);
+        webSettings.setBuiltInZoomControls(true);
+        webSettings.setDisplayZoomControls(false);
+        webSettings.setSupportZoom(true);
+        webSettings.setDefaultTextEncodingName("utf-8");
+        cacheWebView.loadUrl("https://www.memoryexpansiontools.com");
     }
 }

--- a/JetpackSAM/app/src/main/java/com/memoryexpansiontools/mxt/CacheActivity.java
+++ b/JetpackSAM/app/src/main/java/com/memoryexpansiontools/mxt/CacheActivity.java
@@ -1,6 +1,7 @@
 package com.memoryexpansiontools.mxt;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 
 import android.os.Bundle;
 import android.webkit.WebSettings;
@@ -14,6 +15,10 @@ public class CacheActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_cache);
+
+        //Create the action bar for this activity
+        Toolbar cache_toolbar = (Toolbar) findViewById(R.id.cache_toolbar);
+;        setSupportActionBar(cache_toolbar);
 
         //Create and load a webview pointed at the memoryexpansiontools website
         //This allows the user to access MXT Cache directly within the app.

--- a/JetpackSAM/app/src/main/java/com/memoryexpansiontools/mxt/CacheActivity.java
+++ b/JetpackSAM/app/src/main/java/com/memoryexpansiontools/mxt/CacheActivity.java
@@ -3,22 +3,59 @@ package com.memoryexpansiontools.mxt;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
+import android.content.Intent;
 import android.os.Bundle;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 
+import com.example.jetpacksam.LoginActivity;
+import com.example.jetpacksam.MainActivity;
 import com.example.jetpacksam.R;
+import com.example.jetpacksam.SettingsActivity;
 
 public class CacheActivity extends AppCompatActivity {
+
+    public static final int NEW_PHRASE_ACTIVITY_REQUEST_CODE = 1;
+    public static final int VIEW_PHRASE_ACTIVITY_REQUEST_CODE = 2;
+    public static final int SETTINGS_ACTIVITY_REQUEST_CODE = 2;
+    public static final int LOGIN_ACTIVITY_REQUEST_CODE = 3;
+    public static final int CACHE_ACTIVITY_REQUEST_CODE = 4; //I don't know what these are for yet but this looks cool
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu){
+        getMenuInflater().inflate(R.menu.cache_actionbar, menu);
+        return super.onCreateOptionsMenu(menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item){
+
+        switch(item.getItemId()){
+            case R.id.action_settings:
+                Intent intent = new Intent(CacheActivity.this, SettingsActivity.class);
+                startActivityForResult(intent, SETTINGS_ACTIVITY_REQUEST_CODE);
+                return true;
+            case R.id.login:
+                Intent logIntent = new Intent(CacheActivity.this, LoginActivity.class);
+                startActivityForResult(logIntent, LOGIN_ACTIVITY_REQUEST_CODE);
+                return true;
+            case R.id.stream:
+                Intent streamIntent = new Intent(CacheActivity.this, MainActivity.class);
+                startActivityForResult(streamIntent, CACHE_ACTIVITY_REQUEST_CODE);
+                return true;
+            default: return super.onOptionsItemSelected(item);
+        }
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_cache);
 
-        //Create the action bar for this activity
-        Toolbar cache_toolbar = (Toolbar) findViewById(R.id.cache_toolbar);
-;        setSupportActionBar(cache_toolbar);
+        Toolbar toolbar = findViewById(R.id.cache_toolbar);
+        setSupportActionBar(toolbar);
 
         //Create and load a webview pointed at the memoryexpansiontools website
         //This allows the user to access MXT Cache directly within the app.

--- a/JetpackSAM/app/src/main/java/com/memoryexpansiontools/mxt/MainActivity.java
+++ b/JetpackSAM/app/src/main/java/com/memoryexpansiontools/mxt/MainActivity.java
@@ -62,7 +62,7 @@ public class MainActivity extends AppCompatActivity implements ItemClickListener
                 return true;
             case R.id.cache:
                 Intent cacheIntent = new Intent(MainActivity.this, CacheActivity.class);
-                startActivityForResult(cacheIntent, LOGIN_ACTIVITY_REQUEST_CODE);
+                startActivityForResult(cacheIntent, CACHE_ACTIVITY_REQUEST_CODE);
                 return true;
             default: return super.onOptionsItemSelected(item);
         }

--- a/JetpackSAM/app/src/main/java/com/memoryexpansiontools/mxt/MainActivity.java
+++ b/JetpackSAM/app/src/main/java/com/memoryexpansiontools/mxt/MainActivity.java
@@ -18,6 +18,8 @@ import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.memoryexpansiontools.mxt.CacheActivity;
+
 import java.util.List;
 
 

--- a/JetpackSAM/app/src/main/java/com/memoryexpansiontools/mxt/MainActivity.java
+++ b/JetpackSAM/app/src/main/java/com/memoryexpansiontools/mxt/MainActivity.java
@@ -26,7 +26,9 @@ public class MainActivity extends AppCompatActivity implements ItemClickListener
     public static final int NEW_PHRASE_ACTIVITY_REQUEST_CODE = 1;
     public static final int VIEW_PHRASE_ACTIVITY_REQUEST_CODE = 2;
     public static final int SETTINGS_ACTIVITY_REQUEST_CODE = 2;
-    public static final int LOGIN_ACTIVITY_REQUEST_CODE = 3; //I don't know what these are for yet but this looks cool
+    public static final int LOGIN_ACTIVITY_REQUEST_CODE = 3;
+    public static final int CACHE_ACTIVITY_REQUEST_CODE = 4; //I don't know what these are for yet but this looks cool
+
     public static final String LOG_TAG = MainActivity.class.getName();
 
     private PhraseViewModel mPhraseViewModel;
@@ -55,6 +57,10 @@ public class MainActivity extends AppCompatActivity implements ItemClickListener
             case R.id.login:
                 Intent logIntent = new Intent(MainActivity.this, LoginActivity.class);
                 startActivityForResult(logIntent, LOGIN_ACTIVITY_REQUEST_CODE);
+                return true;
+            case R.id.cache:
+                Intent cacheIntent = new Intent(MainActivity.this, CacheActivity.class);
+                startActivityForResult(cacheIntent, LOGIN_ACTIVITY_REQUEST_CODE);
                 return true;
             default: return super.onOptionsItemSelected(item);
         }

--- a/JetpackSAM/app/src/main/res/drawable/ic_memory_black_24dp.xml
+++ b/JetpackSAM/app/src/main/res/drawable/ic_memory_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M15,9L9,9v6h6L15,9zM13,13h-2v-2h2v2zM21,11L21,9h-2L19,7c0,-1.1 -0.9,-2 -2,-2h-2L15,3h-2v2h-2L11,3L9,3v2L7,5c-1.1,0 -2,0.9 -2,2v2L3,9v2h2v2L3,13v2h2v2c0,1.1 0.9,2 2,2h2v2h2v-2h2v2h2v-2h2c1.1,0 2,-0.9 2,-2v-2h2v-2h-2v-2h2zM17,17L7,17L7,7h10v10z"/>
+</vector>

--- a/JetpackSAM/app/src/main/res/drawable/ic_play_arrow_black_24dp.xml
+++ b/JetpackSAM/app/src/main/res/drawable/ic_play_arrow_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M8,5v14l11,-7z"/>
+</vector>

--- a/JetpackSAM/app/src/main/res/drawable/ic_web_asset_black_24dp.xml
+++ b/JetpackSAM/app/src/main/res/drawable/ic_web_asset_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:pathData="M19,4L5,4c-1.11,0 -2,0.9 -2,2v12c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2L21,6c0,-1.1 -0.89,-2 -2,-2zM19,18L5,18L5,8h14v10z"
+        android:fillColor="#010101"/>
+</vector>

--- a/JetpackSAM/app/src/main/res/layout/activity_cache.xml
+++ b/JetpackSAM/app/src/main/res/layout/activity_cache.xml
@@ -6,6 +6,18 @@
     android:layout_height="match_parent"
     tools:context="com.memoryexpansiontools.mxt.CacheActivity">
 
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/main_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        android:elevation="4dp"
+        android:theme="@style/ThemeOverlay.AppCompat.ActionBar"
+        app:layout_constraintTop_toTopOf="parent"
+        app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+        app:title="MXT"
+        />
+
     <WebView
         android:id="@+id/cacheView"
         android:layout_width="match_parent"

--- a/JetpackSAM/app/src/main/res/layout/activity_cache.xml
+++ b/JetpackSAM/app/src/main/res/layout/activity_cache.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="com.memoryexpansiontools.mxt.CacheActivity">
+
+    <WebView
+        android:id="@+id/cacheView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/JetpackSAM/app/src/main/res/layout/activity_cache.xml
+++ b/JetpackSAM/app/src/main/res/layout/activity_cache.xml
@@ -7,7 +7,7 @@
     tools:context="com.memoryexpansiontools.mxt.CacheActivity">
 
     <androidx.appcompat.widget.Toolbar
-        android:id="@+id/main_toolbar"
+        android:id="@+id/cache_toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/colorPrimary"

--- a/JetpackSAM/app/src/main/res/menu/cache_actionbar.xml
+++ b/JetpackSAM/app/src/main/res/menu/cache_actionbar.xml
@@ -8,9 +8,9 @@
         app:showAsAction="ifRoom"/>
 
     <item
-        android:id="@+id/cache"
-        android:icon="@drawable/ic_memory_black_24dp"
-        android:title="@string/cache"
+        android:id="@+id/stream"
+        android:icon="@drawable/ic_play_arrow_black_24dp"
+        android:title="@string/stream"
         app:showAsAction="ifRoom"/>
 
     <item

--- a/JetpackSAM/app/src/main/res/menu/main_actionbar.xml
+++ b/JetpackSAM/app/src/main/res/menu/main_actionbar.xml
@@ -8,6 +8,12 @@
         app:showAsAction="ifRoom"/>
 
     <item
+        android:id="@+id/cache"
+        android:icon="@drawable/ic_web_asset_black_24dp"
+        android:title="@string/cache"
+        app:showAsAction="ifRoom"/>
+
+    <item
         android:id="@+id/action_settings"
         android:icon="@drawable/ic_settings_24px"
         android:title="@string/action_settings"

--- a/JetpackSAM/app/src/main/res/values/strings.xml
+++ b/JetpackSAM/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="title_activity_settings">Settings</string>
     <string name="medium_text">text</string>
     <string name="medium_spoken">spoken</string>
+    <string name="cache">cache</string>
 
     <!-- Preference Titles -->
     <string name="data_streams_header">Data Streams</string>

--- a/JetpackSAM/app/src/main/res/values/strings.xml
+++ b/JetpackSAM/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="medium_text">text</string>
     <string name="medium_spoken">spoken</string>
     <string name="cache">cache</string>
+    <string name="stream">stream</string>
 
     <!-- Preference Titles -->
     <string name="data_streams_header">Data Streams</string>


### PR DESCRIPTION
This PR focuses on merging MXT Cache into the app by utilizing the Webview widget to pull up the web page rather than natively building out a new activity/fragment.

This is ideally a holdover until a native solution can be built which will likely be much more efficient. This was done to reduce the time needed to start coding the onboarding portion of the app.